### PR TITLE
修改一个tars.tarsAdminRegistry停机其他管理服务不能正常工作的问题

### DIFF
--- a/RegistryServer/DbHandle.cpp
+++ b/RegistryServer/DbHandle.cpp
@@ -1216,8 +1216,7 @@ int CDbHandle::loadObjectIdCache(const bool bRecoverProtect, const int iRecoverP
 
                 ServantStatusKey statusKey = { res[i]["application"], res[i]["server_name"], res[i]["node_name"] }; 
                 
-                if ((res[i]["setting_state"] == "active" && res[i]["present_state"] == "active") 
-                    || res[i]["servant"] == "tars.tarsAdminRegistry.AdminRegObj") //如果是管理服务, 强制认为它是活的
+                if (res[i]["setting_state"] == "active" && res[i]["present_state"] == "active")    
                 {
                     //存活列表
                     objectsCache[res[i]["servant"]].vActiveEndpoints.push_back(epf);


### PR DESCRIPTION
一个tars.tarsAdminRegistry停掉其他服务不能正常工作的问题
去掉1220行判断特例情况，此判断会导致已下线的tars.tarsAdminRegistry服务被误用，造成其他管理服务不能正常工作；

删掉如下代码：
||res[i]["servant"] == "tars.tarsAdminRegistry.AdminRegObj"