### PR TITLE
Fix server state error

### DIFF
--- a/NodeServer/ServerObject.cpp
+++ b/NodeServer/ServerObject.cpp
@@ -258,11 +258,12 @@ void ServerObject::synState()
         //防止主控超时导致阻塞服务上报心跳
         if(_noticeFailTimes < 3)
         {
-            AdminProxy::getInstance()->getRegistryProxy()->tars_set_timeout(1000)->updateServer( _nodeInfo.nodeName,  _application, _serverName, tServerStateInfo);
+            int ret = AdminProxy::getInstance()->getRegistryProxy()->tars_set_timeout(1000)->updateServer( _nodeInfo.nodeName,  _application, _serverName, tServerStateInfo);
+            onUpdateServerResult(ret);
         }
         else
         {
-            AdminProxy::getInstance()->getRegistryProxy()->async_updateServer(NULL, _nodeInfo.nodeName,  _application, _serverName, tServerStateInfo);
+            AdminProxy::getInstance()->getRegistryProxy()->async_updateServer(this, _nodeInfo.nodeName,  _application, _serverName, tServerStateInfo);
         }
 
         //日志
@@ -270,8 +271,8 @@ void ServerObject::synState()
         tServerStateInfo.displaySimple(ss);
         NODE_LOG(_serverId)->debug()<<FILE_FUN << "synState" << "|"<< _nodeInfo.nodeName << "|" <<  _serverId << "|" << std::boolalpha << _enSynState <<"|" << ss.str() << endl;
 
-        _noticed = true;
-        _noticeFailTimes = 0;
+        //_noticed = true;
+        //_noticeFailTimes = 0;
     }
     catch (exception &e)
     {
@@ -290,7 +291,7 @@ void ServerObject::asyncSynState()
         ServerStateInfo tServerStateInfo;
         tServerStateInfo.serverState    = (IsEnSynState()?toServerState(_state):tars::Inactive);
         tServerStateInfo.processId      = _pid;
-        AdminProxy::getInstance()->getRegistryProxy()->async_updateServer( NULL, _nodeInfo.nodeName,  _application, _serverName, tServerStateInfo);
+        AdminProxy::getInstance()->getRegistryProxy()->async_updateServer( this, _nodeInfo.nodeName,  _application, _serverName, tServerStateInfo);
 
         //日志
         stringstream ss;
@@ -966,4 +967,34 @@ void ServerObject::setStartTime(int64_t iStartTime)
 {
 	Lock lock(*this);
 	_startTime = iStartTime;
+}
+
+void ServerObject::onUpdateServerResult(int result)
+{
+    if(result < 0)
+    {
+        _noticed = false;
+        _noticeFailTimes ++;
+
+        TLOGERROR("Update server:"<<_application<<"."<<_serverName<<" failed, error times:"<<_noticeFailTimes<<", result:"<<result<< endl);
+    }
+    else
+    {
+        _noticed = true;
+        _noticeFailTimes = 0;
+
+        TLOGDEBUG("Update server: "<<_application<<"."<<_serverName<<" ok"<<endl);
+    }
+}
+
+void ServerObject::callback_updateServer(tars::Int32 ret)
+{
+    onUpdateServerResult(ret);
+}
+
+void ServerObject::callback_updateServer_exception(tars::Int32 ret)
+{
+    onUpdateServerResult(ret == 0 ? -1 : ret);
+}
+
 }

--- a/NodeServer/ServerObject.cpp
+++ b/NodeServer/ServerObject.cpp
@@ -996,5 +996,3 @@ void ServerObject::callback_updateServer_exception(tars::Int32 ret)
 {
     onUpdateServerResult(ret == 0 ? -1 : ret);
 }
-
-}

--- a/NodeServer/ServerObject.h
+++ b/NodeServer/ServerObject.h
@@ -33,7 +33,8 @@
 using namespace tars;
 using namespace std;
 
-class ServerObject : public TC_ThreadRecLock, public TC_HandleBase
+//class ServerObject : public TC_ThreadRecLock, public TC_HandleBase
+class ServerObject : public TC_ThreadRecLock, public RegistryPrxCallback
 {
 public:
     enum InternalServerState
@@ -468,6 +469,13 @@ public:
     void setServerLimitInfo(const ServerLimitInfo& tInfo);
 
     bool setServerCoreLimit(bool bCloseCore);
+
+public:
+    void onUpdateServerResult(int result);
+
+    virtual void callback_updateServer(tars::Int32 ret);
+
+    virtual void callback_updateServer_exception(tars::Int32 ret);
 
 private:
     bool    _tarsServer;                //是否tars服务

--- a/RegistryServer/DbHandle.cpp
+++ b/RegistryServer/DbHandle.cpp
@@ -638,7 +638,12 @@ int CDbHandle::doUpdateServerStateBatch(const std::vector<tars::ServerStateInfo>
                           << "|cost:" << (TNOWMS - iStart) << endl);
 
                 TC_ThreadLock::Lock lock(_mapServantStatusLock);
-                _mapServantStatus.insert(updated_map.begin(), updated_map.end());
+                //insert will fail when map has same key
+                //_mapServantStatus.insert(updated_map.begin(), updated_map.end());
+                for(auto &kv : updated_map)
+                {
+                    _mapServantStatus[kv.first] = kv.second;
+                }
             }
         }
         return 0;


### PR DESCRIPTION
解决以下问题： 
服务通过tarsnode上报状态时，如果遇到数据库异常等原因导致状态信息写入数据库失败， 一定时间段内会存在服务状态异常的问题。