### PR TITLE
make tarsnode quit smoothly on SIGTERM/SIGINT

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,27 @@
+{
+    "configurations": [
+        {
+            "name": "Mac",
+            "defines": [
+                "TARS_MYSQL=1"
+            ],
+            "macFrameworkPath": [
+                "/System/Library/Frameworks",
+                "/Library/Frameworks"
+            ],
+            "intelliSenseMode": "clang-x64",
+            "compilerPath": "/usr/bin/clang",
+            "cStandard": "c11",
+            "cppStandard": "c++17",
+            "includePath": [
+                "build/src/mysql/include",
+                "tarscpp/servant",
+                "patchclient",
+                "tarscpp/servant/protocol/framework",
+                "tarscpp/util/include",
+                "tarscpp/servant/servant"
+            ]
+        }
+    ],
+    "version": 4
+}

--- a/NodeServer/BatchPatchThread.cpp
+++ b/NodeServer/BatchPatchThread.cpp
@@ -55,12 +55,14 @@ void BatchPatch::terminate()
         }
     }
 
+    {
+        TC_ThreadLock::Lock lock(_queueMutex);
+        _queueMutex.notifyAll();
+    }
+
     for (size_t i = 0; i < _runners.size(); ++i)
     {
-        if(_runners[i]->isAlive())
-        {
-            _runners[i]->getThreadControl().join();
-        }
+        _runners[i]->getThreadControl().join();
     }
 
 }
@@ -127,11 +129,6 @@ BatchPatchThread::~BatchPatchThread()
 void BatchPatchThread::terminate()
 {
     _shutDown = true;
-
-    if (isAlive())
-    {
-        getThreadControl().join();
-    }
 }
 
 void BatchPatchThread::doPatchRequest(const tars::PatchRequest & request, ServerObjectPtr server)

--- a/NodeServer/KeepAliveThread.cpp
+++ b/NodeServer/KeepAliveThread.cpp
@@ -53,7 +53,6 @@ void KeepAliveThread::terminate()
 	    TC_ThreadLock::Lock lock(_lock);
 
 	    _lock.notifyAll();
-        getThreadControl().join();
     }
 
     getThreadControl().join();

--- a/NodeServer/RemoveLogThread.cpp
+++ b/NodeServer/RemoveLogThread.cpp
@@ -53,15 +53,15 @@ void RemoveLogManager::terminate()
         }
     }
 
-    for (size_t i = 0; i < _runners.size(); ++i)
     {
-        if(_runners[i]->isAlive())
-        {
-            _runners[i]->getThreadControl().join();
-        }
+        TC_ThreadLock::Lock lock(_queueMutex);
+        _queueMutex.notifyAll();
     }
 
-    _queueMutex.notifyAll();
+    for (size_t i = 0; i < _runners.size(); ++i)
+    {
+        _runners[i]->getThreadControl().join();
+    }
 }
 
 int RemoveLogManager::push_back(const string& logPath)
@@ -119,11 +119,6 @@ RemoveLogThread::~RemoveLogThread()
 void RemoveLogThread::terminate()
 {
     _shutDown = true;
-
-    if (isAlive())
-    {
-        getThreadControl().join();
-    }
 }
 
 void RemoveLogThread::run()

--- a/NodeServer/ReportMemThread.cpp
+++ b/NodeServer/ReportMemThread.cpp
@@ -41,9 +41,10 @@ void ReportMemThread::terminate()
 
     if(isAlive())
     {
+        TC_ThreadLock::Lock lock(_lock);
         _lock.notifyAll();
-        getThreadControl().join();
     }
+    getThreadControl().join();
 }
 
 bool ReportMemThread::timedWait(int millsecond)

--- a/NodeServer/main.cpp
+++ b/NodeServer/main.cpp
@@ -33,9 +33,10 @@ void monitorNode(const string &configFile)
 {
     TC_Config conf;
     conf.parseFile(configFile);
+    CommunicatorPtr c = new Communicator();
 
     string serverObj = "tars.tarsnode.ServerObj@" + conf["/tars/application/server/ServerAdapter<endpoint>"];
-    ServerFPrx sprx = CommunicatorFactory::getInstance()->getCommunicator()->stringToProxy<ServerFPrx>(serverObj);
+    ServerFPrx sprx = c->stringToProxy<ServerFPrx>(serverObj);
     unsigned int latestKeepAliveTime = sprx->tars_set_timeout(2000)->getLatestKeepAliveTime();
     unsigned int kaTimeout = TC_Common::strto<unsigned int>(conf.get("/tars/node/keepalive<synTimeout>", "300"));
     if (latestKeepAliveTime + kaTimeout < TNOW)


### PR DESCRIPTION
This PR fix two things:

1. The `tarsnode` process can not quit upon `kill`. By re-arrange the notify and join, it now has no problem.
2. `tarsnode --monitor` throws an exception on `CommunicatorFactory` singleton destruction during `atexit`, which makes the script `/usr/local/app/tars/check.sh` can not work on macOS.

        $ servers/tarsnode/bin/tarsnode --monitor --config=/usr/local/app/tars/tarsnode/conf/tars.tarsnode.config.conf 
        MonitorNode ok, latestKeepAliveTime:1607764855, kaTimeout:300
        libc++abi.dylib: terminating with uncaught exception of type std::__1::system_error: mutex lock failed: Invalid argument
        Abort trap: 6

    It was fix by use Communicator directly.