### PR TITLE
Added the heartbeat interval configuration for the NodeServer to report the RegistryServer

### DIFF
--- a/NodeServer/KeepAliveThread.cpp
+++ b/NodeServer/KeepAliveThread.cpp
@@ -23,18 +23,19 @@ KeepAliveThread::KeepAliveThread()
 : _terminate(false)
 , _registryPrx(NULL)
 {
-    _runTime           = time(0);
-    _nodeInfo          = _platformInfo.getNodeInfo();
-    _heartTimeout      = TC_Common::strto<int>(g_pconf->get("/tars/node/keepalive<heartTimeout>", "10"));
-    _monitorInterval   = TC_Common::strto<int>(g_pconf->get("/tars/node/keepalive<monitorInterval>", "2"));
+    _runTime                = time(0);
+    _nodeInfo               = _platformInfo.getNodeInfo();
+    _heartTimeout           = TC_Common::strto<int>(g_pconf->get("/tars/node/keepalive<heartTimeout>", "10"));
+    _monitorInterval        = TC_Common::strto<int>(g_pconf->get("/tars/node/keepalive<monitorInterval>", "2"));    
+    _reportAliveInterval    = TC_Common::strto<int>(g_pconf->get("/tars/node/keepalive<reportAliveInterval>", "10"));
 
-    _monitorIntervalMs = TC_Common::strto<int>(g_pconf->get("/tars/node/keepalive<monitorIntervalMs>", "10"));
+    _monitorIntervalMs      = TC_Common::strto<int>(g_pconf->get("/tars/node/keepalive<monitorIntervalMs>", "10"));
 
-    _synInterval       = TC_Common::strto<int>(g_pconf->get("/tars/node/keepalive<synStatInterval>", "60"));
-    _synStatBatch      = g_pconf->get("/tars/node/keepalive<synStatBatch>", "Y");
-    _monitorInterval   = _monitorInterval > 10 ? 10 : (_monitorInterval < 1 ? 1 : _monitorInterval);
+    _synInterval            = TC_Common::strto<int>(g_pconf->get("/tars/node/keepalive<synStatInterval>", "60"));
+    _synStatBatch           = g_pconf->get("/tars/node/keepalive<synStatBatch>", "Y");
+    _monitorInterval        = _monitorInterval > 10 ? 10 : (_monitorInterval < 1 ? 1 : _monitorInterval);
 
-    _latestKeepAliveTime = TNOW;
+    _latestKeepAliveTime    = TNOW;
 
 }
 
@@ -220,7 +221,7 @@ int KeepAliveThread::reportAlive()
     {
         static time_t tReport;
         time_t tNow =  TNOW;
-        if (tNow - tReport > _heartTimeout)
+        if (tNow - tReport > _reportAliveInterval)
         {
             tReport = tNow;
 

--- a/NodeServer/KeepAliveThread.h
+++ b/NodeServer/KeepAliveThread.h
@@ -92,7 +92,8 @@ protected:
     bool                _terminate; 
     time_t              _runTime;              //node运行时间
     int                 _heartTimeout;         //业务心跳超时时间(s)
-    int                 _monitorInterval;      //监控server状态的间隔时间(s)
+    int                 _monitorInterval;      //监控server状态的间隔时间(s)    
+    int                 _reportAliveInterval;  //上报注册中心的心跳间隔(s)
     int                 _monitorIntervalMs;    //新的监控状态间隔，改成毫秒
     int                 _synInterval;          //同步与regisrty server状态的间隔时间(s)
     string              _synStatBatch;         //批量同步


### PR DESCRIPTION
Added the heartbeat interval configuration for the NodeServer to report the RegistryServer:
The timeout time for checking the heartbeat of the business service and the heartbeat time reported by the NodeServer to the RegistryServer share the same configuration. When the nodeTimeout configured by the RegistryServer <heartTimeout, the business services under the NodeServer will sometimes go offline. 
新增NodeServer上报RegistryServer的心跳间隔配置：
检查业务服务心跳的超时时间与NodeServer上报RegistryServer的心跳时间共用了一个配置，当RegistryServer配置的nodeTimeout < heartTimeout的时候，会导致NodeServer下的业务服务有时会不在线