### PR TITLE
Fixed the compilation failure after adding TraceServer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ add_subdirectory(patchclient)
 add_subdirectory(StatServer)
 add_subdirectory(QueryStatServer)
 add_subdirectory(QueryPropertyServer)
-add_subdirectory(TraceServer)
+#add_subdirectory(TraceServer)
 ############################################################################################
 # 打包deploy, 用于部署
 


### PR DESCRIPTION
Fixed the compilation failure after adding TraceServer
加入了TraceServer之后无法编译通过。
CMakeLists.txt 可能需要改成需要改成MODULE 形式:
"set(MODULE "tarstrace")
complice_module(${MODULE})"