### PR TITLE
Fixed bug: when the exe program exists and some files in the bin dire…

### DIFF
--- a/NodeServer/CommandStart.cpp
+++ b/NodeServer/CommandStart.cpp
@@ -76,13 +76,16 @@ ServerCommand::ExeStatus CommandStart::canExecute(string& sResult)
 			string server;
 
     		//为了兼容服务exe文件改名, 如果exeFile不存在, 则遍历目录下, 第一个文件名带Server的可执行程序
-
-			findExe = searchServer(_serverObjectPtr->getExePath(), server);
-
-			if(findExe)
+			if(!TC_File::isFileExist(_exeFile))
 			{
-				_exeFile = server;
+				findExe = searchServer(_serverObjectPtr->getExePath(), server);
+
+				if(findExe)
+				{
+					_exeFile = server;
+				}
 			}
+			
 		}
 		else if(_serverObjectPtr->getServerType() == "tars_nodejs")
 		{


### PR DESCRIPTION
当exe程序存在并且bin目录有些文件包含"server"字符串时,由于目录下的文件排序的先后顺序，可能会导致程序运行失败
Fixed bug: when the exe program exists and some files in the bin directory contain the string "server", the program may fail to run