### PR TITLE
Fix to prevent "t_ecstatus" table from being dropped

### DIFF
--- a/PropertyServer/PropertyServer.cpp
+++ b/PropertyServer/PropertyServer.cpp
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Tencent is pleased to support the open source community by making Tars available.
  *
  * Copyright (C) 2016THL A29 Limited, a Tencent company. All rights reserved.
@@ -129,6 +129,11 @@ void PropertyServer::doReserveDb(const string path, TC_Config *pconf)
 			for(size_t i = 0; i < datas.size(); i++)
 			{
 				string name = datas[i]["table_name"];
+
+                if(name == "t_ecstatus")
+                {
+                    continue;
+                }
 
 				if(name < tableName)
 				{

--- a/PropertyServer/PropertyServer.cpp
+++ b/PropertyServer/PropertyServer.cpp
@@ -130,10 +130,10 @@ void PropertyServer::doReserveDb(const string path, TC_Config *pconf)
 			{
 				string name = datas[i]["table_name"];
 
-                if(name == "t_ecstatus")
-                {
-                    continue;
-                }
+				if(name == "t_ecstatus")
+				{
+				    continue;
+				}
 
 				if(name < tableName)
 				{

--- a/StatServer/StatServer.cpp
+++ b/StatServer/StatServer.cpp
@@ -130,10 +130,10 @@ void StatServer::doReserveDb(const string path, TC_Config *pconf)
 			{
 				string name = datas[i]["table_name"];
 
-                if(name == "t_ecstatus")
-                {
-                    continue;
-                }
+				if(name == "t_ecstatus")
+				{
+				    continue;
+				}
 
 				if(name < tableName)
 				{

--- a/StatServer/StatServer.cpp
+++ b/StatServer/StatServer.cpp
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Tencent is pleased to support the open source community by making Tars available.
  *
  * Copyright (C) 2016THL A29 Limited, a Tencent company. All rights reserved.
@@ -129,6 +129,11 @@ void StatServer::doReserveDb(const string path, TC_Config *pconf)
 			for(size_t i = 0; i < datas.size(); i++)
 			{
 				string name = datas[i]["table_name"];
+
+                if(name == "t_ecstatus")
+                {
+                    continue;
+                }
 
 				if(name < tableName)
 				{


### PR DESCRIPTION
Fix to prevent "t_ecstatus" table from being dropped