### PR TITLE
linux下启动tarsnode后脚本进程不退出问题修复

### DIFF
--- a/NodeServer/main.cpp
+++ b/NodeServer/main.cpp
@@ -126,7 +126,7 @@ int main( int argc, char* argv[] )
 #if !TARGET_PLATFORM_WINDOWS
         if (!bNoDaemon)
         {
-            // TC_Common::daemon();
+            TC_Common::daemon();
         }
 #endif
         parseConfig(argc,argv);


### PR DESCRIPTION
设置tarsnode为守护进程