### PR TITLE
Fixed the issue that tarsregistry sometimes failed to join the service's locator configuration list 

### DIFF
--- a/RegistryServer/ReapThread.cpp
+++ b/RegistryServer/ReapThread.cpp
@@ -75,6 +75,9 @@ int ReapThread::init()
 
     _recoverProtectRate    = _recoverProtectRate   < 1 ? 30: _recoverProtectRate;
 
+    //更新主控心跳时间,设置主控状态为active
+    _db.updateRegistryInfo2Db(_heartBeatOff);
+	
     //加载对象列表
     _db.loadObjectIdCache(_recoverProtect, _recoverProtectRate,0,true, true);
 


### PR DESCRIPTION
Fixed the issue that tarsregistry sometimes failed to join the service's locator configuration list 
多台Tars框架，当中一台服务器重启: 
tarsregistry启动时,需要先更新自己的心跳时间,否则一同启动的tarsnode拉起其它服务时,不能把刚启动的tarsregistry.QueryObj写入其它服务的/client/<locator>配置列表中.