### PR TITLE
Fixed the bug that ports might be used when the service was restarted

### DIFF
--- a/AdminRegistryServer/AdminRegistryImp.cpp
+++ b/AdminRegistryServer/AdminRegistryImp.cpp
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Tencent is pleased to support the open source community by making Tars available.
  *
  * Copyright (C) 2016THL A29 Limited, a Tencent company. All rights reserved.
@@ -56,7 +56,7 @@ int AdminRegistryImp::doClose(CurrentPtr current)
 
 int AdminRegistryImp::reportNode(const ReportNode &rn, CurrentPtr current)
 {
-//	TLOG_DEBUG("nodeName:" << nodeName << ", uid:" << current->getUId() << endl);
+	TLOG_DEBUG("nodeName:" << rn.nodeName << ", uid:" << current->getUId() << endl);
 
 	NodeManager::getInstance()->createNodeCurrent(rn.nodeName, rn.sid, current);
 	return 0;
@@ -598,7 +598,6 @@ int AdminRegistryImp::restartServer(const string & application, const string & s
 
     bool isDnsServer = false;
     int iRet = EM_TARS_SUCCESS;
-    CurrentPtr nodeCurrent = NodeManager::getInstance()->getNodeCurrent(nodeName);
     try
     {
 		if(application == ServerConfig::Application && serverName == ServerConfig::ServerName)
@@ -630,14 +629,10 @@ int AdminRegistryImp::restartServer(const string & application, const string & s
 			{
 				isDnsServer = true;
 			}
-			else if (nodeCurrent)
+			else
 			{
-                iRet = NodeManager::getInstance()->stopServer(application, serverName, nodeName, result, NULL);
+				iRet = NodeManager::getInstance()->stopServer(application, serverName, nodeName, result, current);
 			}
-            else
-            {
-                iRet = NodeManager::getInstance()->stopServer(application, serverName, nodeName, result, current);
-            }
 			TLOG_DEBUG("call node restartServer, stop|" << application << "." << serverName << "_" << nodeName << "|"
 														<< current->getHostName() << ":" << current->getPort() << endl);
 			if (iRet != EM_TARS_SUCCESS)
@@ -669,13 +664,9 @@ int AdminRegistryImp::restartServer(const string & application, const string & s
                 TLOG_DEBUG( "|" << " '" + application  + "." + serverName + "_" + nodeName + "' is tars_dns server" << endl);
                 return DBPROXY->updateServerState(application, serverName, nodeName, "present_state", tars::Active);
             }
-            else if (nodeCurrent)
-            {
-                return NodeManager::getInstance()->startServer(application, serverName, nodeName, result, NULL);
-            }
             else
             {
-                return NodeManager::getInstance()->startServer(application, serverName, nodeName, result, current);
+				return NodeManager::getInstance()->startServer(application, serverName, nodeName, result, current);
             }
         }
         catch(TarsSyncCallTimeoutException& ex)

--- a/AdminRegistryServer/AdminRegistryImp.h
+++ b/AdminRegistryServer/AdminRegistryImp.h
@@ -17,7 +17,6 @@
 #ifndef __AMIN_REGISTRY_H__
 #define __AMIN_REGISTRY_H__
 
-#include "util/tc_common.h"
 #include "AdminReg.h"
 #include "Registry.h"
 #include "Patch.h"

--- a/AdminRegistryServer/ExecuteTask.cpp
+++ b/AdminRegistryServer/ExecuteTask.cpp
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Tencent is pleased to support the open source community by making Tars available.
  *
  * Copyright (C) 2016THL A29 Limited, a Tencent company. All rights reserved.
@@ -15,7 +15,7 @@
  */
 
 #include "ExecuteTask.h"
-#include "servant/Application.h"
+#include "servant/Communicator.h"
 #include "servant/RemoteLogger.h"
 #include "util/tc_timeprovider.h"
 #include <thread>
@@ -24,8 +24,8 @@ extern TC_Config * g_pconf;
 TaskList::TaskList(const TaskReq &taskReq, unsigned int t)
 : _taskReq(taskReq)
 {
-    _adminPrx = Application::getCommunicator()->stringToProxy<AdminRegPrx>(g_pconf->get("/tars/objname<AdminRegObjName>", "tars.tarsAdminRegistry.AdminRegObj"));
-	_adminImp = ExecuteTask::getInstance()->getAdminImp();
+    //_adminPrx = Communicator::getInstance()->stringToProxy<AdminRegPrx>(g_pconf->get("/tars/objname<AdminRegObjName>", ""));
+	_adminPrx = ExecuteTask::getInstance()->getAdminImp();
 
     _taskRsp.taskNo   = _taskReq.taskNo;
     _taskRsp.serial   = _taskReq.serial;
@@ -122,7 +122,7 @@ void TaskList::setRspInfo(size_t index, bool start, EMTaskItemStatus status)
 
     try
     {
-        _adminImp->setTaskItemInfo_inner(rsp.req.itemNo, info);
+        _adminPrx->setTaskItemInfo_inner(rsp.req.itemNo, info);
     }
     catch (exception &ex)
     {
@@ -153,7 +153,7 @@ void TaskList::setRspLog(size_t index, const string &log)
 
     try
     {
-        _adminImp->setTaskItemInfo_inner(rsp.req.itemNo, info);
+        _adminPrx->setTaskItemInfo_inner(rsp.req.itemNo, info);
     }
     catch (exception &ex)
     {
@@ -211,7 +211,7 @@ int TaskList::prepareFile()
 
 			string result;
 
-			int ret = _adminImp->prepareInfo_inner(pi, result);
+			int ret = _adminPrx->prepareInfo_inner(pi, result);
 			if (ret != 0)
 			{
 				TLOG_ERROR("preparePatch_inner error:" << result << endl);
@@ -231,7 +231,7 @@ int TaskList::prepareFile()
 
 		TLOG_DEBUG("preparePatch_inner prepare :" << e.second.application << "." << e.second.serverName << ", patchId:" << e.second.patchId << ", file:" << e.second.patchFile << ", docker image:" << e.second.baseImage << endl);
 
-		int ret = _adminImp->preparePatch_inner(e.second, result);
+		int ret = this->_adminPrx->preparePatch_inner(e.second, result);
 		if(ret != 0)
 		{
 			TLOG_ERROR("preparePatch_inner error:" << result << endl);
@@ -248,7 +248,7 @@ EMTaskItemStatus TaskList::start(const TaskItemReq &req, string &log)
     int ret = -1;
     try
     {
-		ret = _adminPrx->tars_hash(tars::hash<string>()(req.nodeName))->startServer(req.application, req.serverName, req.nodeName, log);
+		ret = _adminPrx->startServer_inner(req.application, req.serverName, req.nodeName, log);
         if (ret == 0)
             return EM_I_SUCCESS;
     }
@@ -268,7 +268,7 @@ EMTaskItemStatus TaskList::restart(const TaskItemReq &req, string &log)
     int ret = -1;
     try
     {
-		ret = _adminPrx->tars_hash(tars::hash<string>()(req.nodeName))->restartServer(req.application, req.serverName, req.nodeName, log);
+		ret = _adminPrx->restartServer_inner(req.application, req.serverName, req.nodeName, log);
         if (ret == 0)
 		{
 	        return EM_I_SUCCESS;
@@ -297,7 +297,7 @@ EMTaskItemStatus TaskList::graceRestart(const TaskItemReq &req, string &log)
             TLOG_ERROR("TaskList::graceRestartServer no servers" << endl);
             return EM_I_FAILED;
         }
-        ret = _adminPrx->tars_hash(tars::hash<string>()(req.nodeName))->notifyServer(req.application, req.serverName, req.nodeName, "tars.gracerestart",log);
+        ret = _adminPrx->notifyServer_inner(req.application, req.serverName, req.nodeName, "tars.gracerestart",log);
         if (ret == 0) {
             return EM_I_SUCCESS;
         }
@@ -317,7 +317,7 @@ EMTaskItemStatus TaskList::undeploy(const TaskItemReq &req, string &log)
     int ret = -1;
     try
     {
-		ret = _adminPrx->tars_hash(tars::hash<string>()(req.nodeName))->undeploy(req.application, req.serverName, req.nodeName, req.userName, log);
+		ret = _adminPrx->undeploy_inner(req.application, req.serverName, req.nodeName, req.userName, log);
         if (ret == 0)
             return EM_I_SUCCESS;
     }
@@ -337,7 +337,7 @@ EMTaskItemStatus TaskList::stop(const TaskItemReq &req, string &log)
     int ret = -1;
     try
     {
-		ret = _adminPrx->tars_hash(tars::hash<string>()(req.nodeName))->stopServer(req.application, req.serverName, req.nodeName, log);
+		ret = _adminPrx->stopServer_inner(req.application, req.serverName, req.nodeName, log);
         if (ret == 0)
             return EM_I_SUCCESS;
     }
@@ -387,7 +387,7 @@ EMTaskItemStatus TaskList::patch(size_t index, const TaskItemReq &req, string &l
 		//外部是串行处理的
         try
         {
-			ret = _adminPrx->tars_hash(tars::hash<string>()(req.nodeName))->batchPatch(patchReq, log);
+			ret = _adminPrx->batchPatch_inner(patchReq, log);
 		}
         catch (exception &ex)
         {
@@ -416,7 +416,7 @@ EMTaskItemStatus TaskList::patch(size_t index, const TaskItemReq &req, string &l
 
             try
             {
-				ret = _adminPrx->tars_hash(tars::hash<string>()(req.nodeName))->getPatchPercent(req.application, req.serverName, req.nodeName, pi);
+				ret = _adminPrx->getPatchPercent_inner(req.application, req.serverName, req.nodeName, pi);
             }
             catch (exception &ex)
             {
@@ -430,14 +430,14 @@ EMTaskItemStatus TaskList::patch(size_t index, const TaskItemReq &req, string &l
             if (ret != 0)
             {
                 log = pi.sResult;
-				_adminImp->updatePatchLog_inner(req.application, req.serverName, req.nodeName, patchId, req.userName, patchType, false);
+				_adminPrx->updatePatchLog_inner(req.application, req.serverName, req.nodeName, patchId, req.userName, patchType, false);
                 TLOG_ERROR("getPatchPercent error, ret:" << ret << ", " << req.application << "." << req.serverName << "_" << req.nodeName << ", percent:" << pi.iPercent << ", log:" << pi.sResult << endl);
                 return EM_I_FAILED;
             }
 
             if(pi.iPercent == 100 && pi.bSucc)
             {
-				_adminImp->updatePatchLog_inner(req.application, req.serverName, req.nodeName, patchId, req.userName, patchType, true);
+				_adminPrx->updatePatchLog_inner(req.application, req.serverName, req.nodeName, patchId, req.userName, patchType, true);
                 TLOG_DEBUG("getPatchPercent ok, percent:" << pi.iPercent << "%" << endl);
                 retStatus = EM_I_SUCCESS;
                 break;
@@ -460,6 +460,98 @@ EMTaskItemStatus TaskList::patch(size_t index, const TaskItemReq &req, string &l
     }
     return EM_I_SUCCESS; 
 }
+//
+//EMTaskItemStatus TaskList::patch(const TaskItemReq &req, string &log,std::size_t index)
+//{
+//    try
+//	{
+//        int ret = EM_TARS_UNKNOWN_ERR;
+//
+//        TLOG_DEBUG("TaskList::patch:" << TC_Common::tostr(req.parameters.begin(), req.parameters.end())
+//                                     << req.application << "." << req.serverName << ", " << req.nodeName << endl);
+//
+//        string patchId = get("patch_id", req.parameters);
+//        string patchType = get("patch_type", req.parameters);
+//		string runType = get("run_type",req.parameters);
+//
+//        tars::PatchRequest patchReq;
+//        patchReq.appname = req.application;
+//        patchReq.servername = req.serverName;
+//        patchReq.nodename = req.nodeName;
+//        patchReq.version = patchId;
+//        patchReq.user = req.userName;
+//		patchReq.md5 = get("run_type",req.parameters);
+//
+//		//外部是并行处理的!
+//        try {
+////            ret = _adminPrx->preparePatch_inner(patchReq, log, index != 0, taskItemSharedState);
+////            if (ret != 0) {
+////                log = "tarsAdminRegistry batchPatch err:" + log;
+////                TLOG_ERROR("TaskList::patch batchPatch error:" << log << endl);
+////                return EM_I_FAILED;
+////            }
+//			ret = _adminPrx->batchPatch_inner(patchReq, runType=="container", log);
+//        }
+//        catch (exception &ex)
+//        {
+//            log = ex.what();
+//            TLOG_ERROR("TaskList::patch batchPatch error:" << log << endl);
+//            return EM_I_FAILED;
+//        }
+//
+//        if (ret != EM_TARS_SUCCESS)
+//        {
+//            log = "tarsAdminRegistry batchPatch err:" + log;
+//            return EM_I_FAILED;
+//        }
+//
+//		// 这里做个超时保护， 否则如果tarsnode状态错误， 这里一直循环调用
+//		time_t tNow = TNOW;
+//        unsigned int patchTimeout = TC_Common::strto<unsigned int>(g_pconf->get("/tars/patch/<patch_wait_timeout>", "300"));
+//
+//        EMTaskItemStatus retStatus = EM_I_FAILED;
+//        while (TNOW < tNow + patchTimeout)
+//        {
+//            PatchInfo pi;
+//
+//            try
+//            {
+//				ret = _adminPrx->getPatchPercent_inner(req.application, req.serverName, req.nodeName, pi);
+//            }
+//            catch (exception &ex)
+//            {
+//                log = ex.what();
+//                TLOG_ERROR("TaskList::patch getPatchPercent error, ret:" << ret << endl);
+//            }
+//
+//            if (ret != 0)
+//            {
+//				_adminPrx->updatePatchLog_inner(req.application, req.serverName, req.nodeName, patchId, req.userName, patchType, false);
+//                TLOG_ERROR("TaskList::patch getPatchPercent error, ret:" << ret << endl);
+//                return EM_I_FAILED;
+//            }
+//
+//            if(pi.iPercent == 100 && pi.bSucc)
+//            {
+//				_adminPrx->updatePatchLog_inner(req.application, req.serverName, req.nodeName, patchId, req.userName, patchType, true);
+//                TLOG_DEBUG("TaskList::patch getPatchPercent ok, percent:" << pi.iPercent << "%" << endl);
+//                retStatus = EM_I_SUCCESS;
+//                break;
+//            }
+//
+//            TLOG_DEBUG("TaskList::patch getPatchPercent percent:" << pi.iPercent << "%, succ:" << pi.bSucc << endl);
+//
+//			std::this_thread::sleep_for(std::chrono::seconds(1));
+//        }
+//        return retStatus;
+//    }
+//    catch (exception &ex)
+//    {
+//        TLOG_ERROR("TaskList::patch error:" << ex.what() << endl);
+//        return EM_I_FAILED;
+//    }
+//    return EM_I_FAILED;
+//}
 
 EMTaskItemStatus TaskList::executeSingleTask(size_t index, const TaskItemReq &req)
 {

--- a/AdminRegistryServer/ExecuteTask.h
+++ b/AdminRegistryServer/ExecuteTask.h
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Tencent is pleased to support the open source community by making Tars available.
  *
  * Copyright (C) 2016THL A29 Limited, a Tencent company. All rights reserved.
@@ -110,8 +110,7 @@ protected:
     //返回任务
     TaskRsp         _taskRsp;
 
-    AdminRegPrx	_adminPrx;
-    AdminRegistryImp*	_adminImp;
+	AdminRegistryImp*	_adminPrx;
     time_t          _createTime;
     unsigned int    _timeout;
     bool            _finished;

--- a/AdminRegistryServer/NodeManager.cpp
+++ b/AdminRegistryServer/NodeManager.cpp
@@ -415,6 +415,8 @@ int NodeManager::requestNode(const string & nodeName, string &out, CurrentPtr cu
 
 		_timeoutQueue.push(ptr, ptr->_requestId);
 
+		TLOG_DEBUG("requestNode: requestId:" << ptr->_requestId << ", " << nodeName << ", nodeName" <<endl);
+
 		if(current)
 		{
 			//异步
@@ -494,9 +496,9 @@ int NodeManager::requestNode(const string & nodeName, string &out, CurrentPtr cu
 int NodeManager::pingNode(const string & nodeName, string &out, tars::CurrentPtr current)
 {
 	NodeManager::push_type push = [nodeName](CurrentPtr &nodeCurrent, int requestId){
-		TLOG_DEBUG("NodeManager::pingNode push name:" << nodeName <<endl);
+		TLOG_DEBUG("NodeManager::pingNode push name:" << nodeName << ", LocalIp:" << ServerConfig::LocalIp << endl);
 
-		NodePush::async_response_push_ping(nodeCurrent, requestId, nodeName);
+		NodePush::async_response_push_ping(nodeCurrent, requestId, ServerConfig::LocalIp);
 	};
 
 	NodeManager::callback_type callback = [nodeName](CurrentPtr &current, bool timeout, int ret, const string &buff)
@@ -535,8 +537,8 @@ int NodeManager::pingNode(const string & nodeName, string &out, tars::CurrentPtr
 int NodeManager::shutdownNode(const string & nodeName, string &out, tars::CurrentPtr current)
 {
 	NodeManager::push_type push = [nodeName](CurrentPtr &nodeCurrent, int requestId){
-		TLOG_DEBUG("NodeManager::shutdownNode push name:" << nodeName<<endl);
-		NodePush::async_response_push_shutdown(nodeCurrent, requestId, nodeName);
+		TLOG_DEBUG("NodeManager::shutdownNode push name:" << nodeName<< ", LocalIp:" << ServerConfig::LocalIp << endl);
+		NodePush::async_response_push_shutdown(nodeCurrent, requestId, ServerConfig::LocalIp);
 	};
 
 	NodeManager::callback_type callback = [nodeName](CurrentPtr &current, bool timeout, int ret, const string &buff)
@@ -580,8 +582,8 @@ int NodeManager::shutdownNode(const string & nodeName, string &out, tars::Curren
 int NodeManager::getServerState(const string & application, const string & serverName, const string & nodeName, const ServerStateDesc &desc, string &out, tars::CurrentPtr current)
 {
 	NodeManager::push_type push = [application, serverName, nodeName](CurrentPtr &nodeCurrent, int requestId){
-		TLOG_DEBUG("NodeManager::getServerState push name:" << nodeName <<endl);
-		NodePush::async_response_push_getStateInfo(nodeCurrent, requestId, nodeName, application, serverName);
+		TLOG_DEBUG("NodeManager::getServerState push name:" << nodeName << ", LocalIp:" << ServerConfig::LocalIp << endl);
+		NodePush::async_response_push_getStateInfo(nodeCurrent, requestId, ServerConfig::LocalIp, application, serverName);
 	};
 
 	NodeManager::callback_type callback = [application, serverName, nodeName, desc](CurrentPtr &current, bool timeout, int ret, const string &buff)
@@ -656,8 +658,8 @@ int NodeManager::getServerState(const string & application, const string & serve
 int NodeManager::startServer(const string & application, const string & serverName, const string & nodeName, string &out, tars::CurrentPtr current)
 {
 	NodeManager::push_type push = [application, serverName, nodeName](CurrentPtr &nodeCurrent, int requestId){
-		TLOG_DEBUG("NodeManager::startServer push :" << application << "." << serverName << "_" << nodeName <<endl);
-		NodePush::async_response_push_startServer(nodeCurrent, requestId, nodeName, application, serverName);
+		TLOG_DEBUG("NodeManager::startServer push :" << application << "." << serverName << "_" << nodeName << ", LocalIp:" << ServerConfig::LocalIp << endl);
+		NodePush::async_response_push_startServer(nodeCurrent, requestId, ServerConfig::LocalIp, application, serverName);
 	};
 
 	NodeManager::callback_type callback = [application, serverName, nodeName](CurrentPtr &current, bool timeout, int ret, const string &buff)
@@ -698,8 +700,8 @@ int NodeManager::startServer(const string & application, const string & serverNa
 int NodeManager::destroyServer(const string & application, const string & serverName, const string & nodeName, string & out, tars::CurrentPtr current)
 {
 	NodeManager::push_type push = [application, serverName, nodeName](CurrentPtr &nodeCurrent, int requestId){
-		TLOG_DEBUG("NodeManager::destroyServer push :" << application << "." << serverName << "_" << nodeName <<endl);
-		NodePush::async_response_push_destroyServer(nodeCurrent, requestId, nodeName, application, serverName);
+		TLOG_DEBUG("NodeManager::destroyServer push :" << application << "." << serverName << "_" << nodeName << ", LocalIp:" << ServerConfig::LocalIp << endl);
+		NodePush::async_response_push_destroyServer(nodeCurrent, requestId, ServerConfig::LocalIp, application, serverName);
 	};
 
 	NodeManager::callback_type callback = [application, serverName, nodeName](CurrentPtr &current, bool timeout, int ret, const string &buff)
@@ -740,8 +742,8 @@ int NodeManager::destroyServer(const string & application, const string & server
 int NodeManager::stopServer(const string & application, const string & serverName, const string & nodeName, string &out, tars::CurrentPtr current)
 {
 	NodeManager::push_type push = [application, serverName, nodeName](CurrentPtr &nodeCurrent, int requestId){
-		TLOG_DEBUG("NodeManager::stopServer push :" << application << "." << serverName << "_" << nodeName <<endl);
-		NodePush::async_response_push_stopServer(nodeCurrent, requestId, nodeName, application, serverName);
+		TLOG_DEBUG("NodeManager::stopServer push :" << application << "." << serverName << "_" << nodeName<< ", LocalIp:" << ServerConfig::LocalIp << endl);
+		NodePush::async_response_push_stopServer(nodeCurrent, requestId, ServerConfig::LocalIp, application, serverName);
 	};
 
 	NodeManager::callback_type callback = [application, serverName, nodeName](CurrentPtr &current, bool timeout, int ret, const string &buff)
@@ -782,8 +784,8 @@ int NodeManager::stopServer(const string & application, const string & serverNam
 int NodeManager::notifyServer(const string & application, const string & serverName, const string & nodeName, const string &command, string & out, tars::CurrentPtr current)
 {
 	NodeManager::push_type push = [application, serverName, nodeName, command](CurrentPtr &nodeCurrent, int requestId){
-		TLOG_DEBUG("NodeManager::notifyServer push :" << application << "." << serverName << "_" << nodeName <<endl);
-		NodePush::async_response_push_notifyServer(nodeCurrent, requestId, nodeName, application, serverName, command);
+		TLOG_DEBUG("NodeManager::notifyServer push :" << application << "." << serverName << "_" << nodeName << ", LocalIp:" << ServerConfig::LocalIp << endl);
+		NodePush::async_response_push_notifyServer(nodeCurrent, requestId, ServerConfig::LocalIp, application, serverName, command);
 	};
 
 	NodeManager::callback_type callback = [application, serverName, nodeName](CurrentPtr &current, bool timeout, int ret, const string &buff)
@@ -824,8 +826,8 @@ int NodeManager::notifyServer(const string & application, const string & serverN
 int NodeManager::patchPro(const tars::PatchRequest &req, string & out, tars::CurrentPtr current)
 {
 	NodeManager::push_type push = [req](CurrentPtr &nodeCurrent, int requestId){
-		TLOG_DEBUG("NodeManager::patchPro push :" << req.appname << "." << req.servername << "_" << req.nodename <<endl);
-		NodePush::async_response_push_patchPro(nodeCurrent, requestId, req.nodename, req);
+		TLOG_DEBUG("NodeManager::patchPro push :" << req.appname << "." << req.servername << "_" << req.nodename << ", LocalIp:" << ServerConfig::LocalIp << endl);
+		NodePush::async_response_push_patchPro(nodeCurrent, requestId, ServerConfig::LocalIp, req);
 	};
 
 	NodeManager::callback_type callback = [req](CurrentPtr &current, bool timeout, int ret, const string &buff)
@@ -867,8 +869,8 @@ int NodeManager::patchPro(const tars::PatchRequest &req, string & out, tars::Cur
 int NodeManager::getPatchPercent(const string & application, const string & serverName, const string & nodeName, string & out, tars::CurrentPtr current)
 {
 	NodeManager::push_type push = [application, serverName, nodeName](CurrentPtr &nodeCurrent, int requestId){
-		TLOG_DEBUG("NodeManager::getPatchPercent push :" << application << "." << serverName << "_" << nodeName <<endl);
-		NodePush::async_response_push_getPatchPercent(nodeCurrent, requestId, nodeName, application, serverName);
+		TLOG_DEBUG("NodeManager::getPatchPercent push :" << application << "." << serverName << "_" << nodeName << ", LocalIp:" << ServerConfig::LocalIp << endl);
+		NodePush::async_response_push_getPatchPercent(nodeCurrent, requestId, ServerConfig::LocalIp, application, serverName);
 	};
 
 	NodeManager::callback_type callback = [application, serverName, nodeName](CurrentPtr &current, bool timeout, int ret, const string &buff)
@@ -934,8 +936,8 @@ int NodeManager::getPatchPercent(const string & application, const string & serv
 int NodeManager::delCache(const string & nodeName, const std::string & sFullCacheName, const std::string &sBackupPath, const std::string & sKey, std::string &out,CurrentPtr current)
 {
 	NodeManager::push_type push = [nodeName, sFullCacheName, sBackupPath, sKey](CurrentPtr &nodeCurrent, int requestId){
-		TLOG_DEBUG("NodeManager::delCache push :" << sFullCacheName << ", " << sBackupPath << "_" << nodeName << endl);
-		NodePush::async_response_push_delCache(nodeCurrent, requestId, nodeName, sFullCacheName, sBackupPath, sKey);
+		TLOG_DEBUG("NodeManager::delCache push :" << sFullCacheName << ", " << sBackupPath << "_" << nodeName << ", LocalIp:" << ServerConfig::LocalIp << endl);
+		NodePush::async_response_push_delCache(nodeCurrent, requestId, ServerConfig::LocalIp, sFullCacheName, sBackupPath, sKey);
 	};
 
 	NodeManager::callback_type callback = [nodeName](CurrentPtr &current, bool timeout, int ret, const string &buff)
@@ -976,8 +978,8 @@ int NodeManager::delCache(const string & nodeName, const std::string & sFullCach
 int NodeManager::getLogData(const std::string & application, const std::string & serverName, const std::string & nodeName, const std::string &logFile, const std::string &cmd, map<string, string> &context,  string & out, tars::CurrentPtr current)
 {
 	NodeManager::push_type push = [application, serverName, nodeName, logFile, cmd, context](CurrentPtr &nodeCurrent, int requestId){
-		TLOG_DEBUG("NodeManager::getLogData push :" << application << "." << serverName << "_" << nodeName <<endl);
-		NodePush::async_response_push_getLogData(nodeCurrent, requestId, nodeName, application, serverName, logFile, cmd, context);
+		TLOG_DEBUG("NodeManager::getLogData push :" << application << "." << serverName << "_" << nodeName << ", LocalIp:" << ServerConfig::LocalIp << endl);
+		NodePush::async_response_push_getLogData(nodeCurrent, requestId, ServerConfig::LocalIp, application, serverName, logFile, cmd, context);
 	};
 
 	NodeManager::callback_type callback = [application, serverName, nodeName](CurrentPtr &current, bool timeout, int ret, const string &buff)
@@ -1025,8 +1027,8 @@ int NodeManager::getLogData(const std::string & application, const std::string &
 int NodeManager::getLogFileList(const std::string & application, const std::string & serverName, const std::string & nodeName, map<string, string> &context, string & out, tars::CurrentPtr current)
 {
 	NodeManager::push_type push = [application, serverName, nodeName,context](CurrentPtr &nodeCurrent, int requestId){
-		TLOG_DEBUG("NodeManager::getLogFileList push :" << application << "." << serverName << "_" << nodeName <<endl);
-		NodePush::async_response_push_getLogFileList(nodeCurrent, requestId, nodeName, application, serverName, context);
+		TLOG_DEBUG("NodeManager::getLogFileList push :" << application << "." << serverName << "_" << nodeName << ", LocalIp:" << ServerConfig::LocalIp << endl);
+		NodePush::async_response_push_getLogFileList(nodeCurrent, requestId, ServerConfig::LocalIp, application, serverName, context);
 	};
 
 	NodeManager::callback_type callback = [application, serverName, nodeName](CurrentPtr &current, bool timeout, int ret, const string &buff)
@@ -1089,8 +1091,8 @@ int NodeManager::getLogFileList(const std::string & application, const std::stri
 int NodeManager::getNodeLoad(const std::string & application, const std::string & serverName, const std::string & nodeName, int pid, string & out, tars::CurrentPtr current)
 {
 	NodeManager::push_type push = [application, serverName, nodeName, pid](CurrentPtr &nodeCurrent, int requestId){
-		TLOG_DEBUG("NodeManager::getNodeLoad push :" << application << "." << serverName << "_" << nodeName <<endl);
-		NodePush::async_response_push_getNodeLoad(nodeCurrent, requestId, nodeName, application, serverName, pid);
+		TLOG_DEBUG("NodeManager::getNodeLoad push :" << application << "." << serverName << "_" << nodeName << ", LocalIp:" << ServerConfig::LocalIp << endl);
+		NodePush::async_response_push_getNodeLoad(nodeCurrent, requestId, ServerConfig::LocalIp, application, serverName, pid);
 	};
 
 	NodeManager::callback_type callback = [application, serverName, nodeName](CurrentPtr &current, bool timeout, int ret, const string &buff)
@@ -1145,8 +1147,8 @@ int NodeManager::getNodeLoad(const std::string & application, const std::string 
 int NodeManager::loadServer(const std::string & application, const std::string & serverName, const std::string & nodeName, string & out, tars::CurrentPtr current)
 {
 	NodeManager::push_type push = [application, serverName, nodeName](CurrentPtr &nodeCurrent, int requestId){
-		TLOG_DEBUG("NodeManager::loadServer push :" << application << "." << serverName << "_" << nodeName <<endl);
-		NodePush::async_response_push_loadServer(nodeCurrent, requestId, nodeName, application, serverName);
+		TLOG_DEBUG("NodeManager::loadServer push :" << application << "." << serverName << "_" << nodeName << ", LocalIp:" << ServerConfig::LocalIp << endl);
+		NodePush::async_response_push_loadServer(nodeCurrent, requestId, ServerConfig::LocalIp, application, serverName);
 	};
 
 	NodeManager::callback_type callback = [application, serverName, nodeName](CurrentPtr &current, bool timeout, int ret, const string &buff)
@@ -1187,8 +1189,8 @@ int NodeManager::loadServer(const std::string & application, const std::string &
 int NodeManager::forceDockerLogin(const std::string & nodeName, string & out, tars::CurrentPtr current)
 {
 	NodeManager::push_type push = [nodeName](CurrentPtr &nodeCurrent, int requestId){
-		TLOG_DEBUG("NodeManager::forceDockerLogin push :" << nodeName<<endl);
-		NodePush::async_response_push_forceDockerLogin(nodeCurrent, requestId, nodeName);
+		TLOG_DEBUG("NodeManager::forceDockerLogin push :" << nodeName << ", LocalIp:" << ServerConfig::LocalIp << endl);
+		NodePush::async_response_push_forceDockerLogin(nodeCurrent, requestId, ServerConfig::LocalIp);
 	};
 
 	NodeManager::callback_type callback = [nodeName](CurrentPtr &current, bool timeout, int ret, const string &buff)

--- a/NodeServer/ServerManager.cpp
+++ b/NodeServer/ServerManager.cpp
@@ -19,7 +19,7 @@ extern BatchPatch * g_BatchPatchThread;
 class AdminNodePushPrxCallback : public NodePushPrxCallback
 {
 public:
-	AdminNodePushPrxCallback(AdminRegPrx &prx) : _adminPrx(prx)
+	AdminNodePushPrxCallback(map<string, AdminRegPrx> *adminPrxs) : _adminPrxs(adminPrxs)
 	{
 	}
 
@@ -34,7 +34,7 @@ public:
 		TarsOutputStream<BufferWriterString> os;
 		os.write(result, 0);
 
-		_adminPrx->tars_hash(tars::hash<string>()(nodeName))->async_reportResult(NULL, requestId, __FUNCTION__, ret, os.getByteBuffer());
+		(*_adminPrxs)[nodeName]->async_reportResult(NULL, requestId, __FUNCTION__, ret, os.getByteBuffer());
 	}
 
 	virtual void callback_getLogData(tars::Int32 requestId, const string &nodeName,  const std::string& application,  const std::string& serverName,  const std::string& logFile,  const std::string& cmd)
@@ -45,7 +45,7 @@ public:
 
 		NODE_LOG(application + "." + serverName)->debug() << "requestId:" << requestId << ", " << logFile << ", " << cmd << ", ret:" << ret << ", " << result << endl;
 
-		_adminPrx->tars_hash(tars::hash<string>()(nodeName))->async_reportResult(NULL, requestId, __FUNCTION__, ret, result);
+		(*_adminPrxs)[nodeName]->async_reportResult(NULL, requestId, __FUNCTION__, ret, result);
 	}
 
 	virtual void callback_getLogFileList(tars::Int32 requestId, const string &nodeName,  const std::string& application,  const std::string& serverName)
@@ -59,7 +59,7 @@ public:
 		TarsOutputStream<BufferWriterString> os;
 		os.write(result, 0);
 
-		_adminPrx->tars_hash(tars::hash<string>()(nodeName))->async_reportResult(NULL, requestId, __FUNCTION__, ret, os.getByteBuffer());
+		(*_adminPrxs)[nodeName]->async_reportResult(NULL, requestId, __FUNCTION__, ret, os.getByteBuffer());
 	}
 
 	virtual void callback_getNodeLoad(tars::Int32 requestId, const string &nodeName,  const std::string& application,  const std::string& serverName, tars::Int32 pid)
@@ -70,7 +70,7 @@ public:
 
 		NODE_LOG(application + "." + serverName)->debug() << "requestId:" << requestId << ", ret:" << ret << ", " << result << endl;
 
-		_adminPrx->tars_hash(tars::hash<string>()(nodeName))->async_reportResult(NULL, requestId, __FUNCTION__, ret, result);
+		(*_adminPrxs)[nodeName]->async_reportResult(NULL, requestId, __FUNCTION__, ret, result);
 	}
 
 	virtual void callback_getPatchPercent(tars::Int32 requestId, const string &nodeName,  const std::string& application,  const std::string& serverName)
@@ -84,7 +84,7 @@ public:
 		TarsOutputStream<BufferWriterString> os;
 		info.writeTo(os);
 
-		_adminPrx->tars_hash(tars::hash<string>()(nodeName))->async_reportResult(NULL, requestId, __FUNCTION__ ,  ret, os.getByteBuffer());
+		(*_adminPrxs)[nodeName]->async_reportResult(NULL, requestId, __FUNCTION__ ,  ret, os.getByteBuffer());
 	}
 
 	virtual void callback_delCache(tars::Int32 requestId,  const std::string& nodeName,  const std::string& sFullCacheName,  const std::string& sBackupPath,  const std::string& sKey)
@@ -95,7 +95,7 @@ public:
 
 		TLOG_DEBUG("requestId:" << requestId << ", " << sFullCacheName << ", " << sBackupPath << ", " << sKey << result << endl);
 
-		_adminPrx->tars_hash(tars::hash<string>()(nodeName))->async_reportResult(NULL, requestId, __FUNCTION__, ret, result);
+		(*_adminPrxs)[nodeName]->async_reportResult(NULL, requestId, __FUNCTION__, ret, result);
 	}
 
 	virtual void callback_getStateInfo(tars::Int32 requestId, const string &nodeName,  const std::string& application,  const std::string& serverName)
@@ -111,7 +111,7 @@ public:
 		os.write(info, 0);
 		os.write(result, 1);
 
-		_adminPrx->tars_hash(tars::hash<string>()(nodeName))->async_reportResult(NULL, requestId, __FUNCTION__, ret, os.getByteBuffer());
+		(*_adminPrxs)[nodeName]->async_reportResult(NULL, requestId, __FUNCTION__, ret, os.getByteBuffer());
 	}
 
 	virtual void callback_loadServer(tars::Int32 requestId, const string &nodeName,  const std::string& application,  const std::string& serverName)
@@ -122,7 +122,7 @@ public:
 
 		NODE_LOG(application + "." + serverName)->debug() << "requestId:" << requestId << ", " << result << endl;
 
-		_adminPrx->tars_hash(tars::hash<string>()(nodeName))->async_reportResult(NULL, requestId, __FUNCTION__, ret, result);
+		(*_adminPrxs)[nodeName]->async_reportResult(NULL, requestId, __FUNCTION__, ret, result);
 	}
 
 	virtual void callback_notifyServer(tars::Int32 requestId, const string &nodeName,  const std::string& application,  const std::string& serverName,  const std::string& command)
@@ -133,7 +133,7 @@ public:
 
 		NODE_LOG(application + "." + serverName)->debug() << "requestId:" << requestId << ", " << command << ", " << result << endl;
 
-		_adminPrx->tars_hash(tars::hash<string>()(nodeName))->async_reportResult(NULL, requestId, __FUNCTION__, ret, result);
+		(*_adminPrxs)[nodeName]->async_reportResult(NULL, requestId, __FUNCTION__, ret, result);
 	}
 
 	virtual void callback_patchPro(tars::Int32 requestId, const string &nodeName,  const tars::PatchRequest& req)
@@ -144,13 +144,13 @@ public:
 
 		NODE_LOG(req.appname+ "." + req.servername)->debug() << "requestId:" << requestId << ", " << result << endl;
 
-		_adminPrx->tars_hash(tars::hash<string>()(nodeName))->async_reportResult(NULL, requestId, __FUNCTION__, ret, result);
+		(*_adminPrxs)[nodeName]->async_reportResult(NULL, requestId, __FUNCTION__, ret, result);
 	}
 
 	virtual void callback_ping(tars::Int32 requestId, const string &nodeName)
 	{
 		TLOG_DEBUG("requestId:" << requestId << endl);
-		_adminPrx->tars_hash(tars::hash<string>()(nodeName))->async_reportResult(NULL, requestId, __FUNCTION__, 0, "ping succ");
+		(*_adminPrxs)[nodeName]->async_reportResult(NULL, requestId, __FUNCTION__, 0, "ping succ");
 	}
 
 	virtual void callback_shutdown(tars::Int32 requestId, const string &nodeName)
@@ -159,7 +159,7 @@ public:
 
 		int ret = ServerManager::getInstance()->shutdown(result);
 
-		_adminPrx->tars_hash(tars::hash<string>()(nodeName))->async_reportResult(NULL, requestId, __FUNCTION__, ret, result);
+		(*_adminPrxs)[nodeName]->async_reportResult(NULL, requestId, __FUNCTION__, ret, result);
 	}
 
 	virtual void callback_destroyServer(tars::Int32 requestId, const string &nodeName,  const std::string& application,  const std::string& serverName)
@@ -170,7 +170,7 @@ public:
 
 		NODE_LOG(application + "." + serverName)->debug() << result << endl;
 
-		_adminPrx->tars_hash(tars::hash<string>()(nodeName))->async_reportResult(NULL, requestId, __FUNCTION__, ret, result);
+		(*_adminPrxs)[nodeName]->async_reportResult(NULL, requestId, __FUNCTION__, ret, result);
 	}
 
 	virtual void callback_startServer(tars::Int32 requestId, const string &nodeName,  const std::string& application,  const std::string& serverName)
@@ -181,7 +181,7 @@ public:
 
 		NODE_LOG(application + "." + serverName)->debug() << result << endl;
 
-		_adminPrx->tars_hash(tars::hash<string>()(nodeName))->async_reportResult(NULL, requestId, __FUNCTION__, ret, result);
+		(*_adminPrxs)[nodeName]->async_reportResult(NULL, requestId, __FUNCTION__, ret, result);
 	}
 
 	virtual void callback_stopServer(tars::Int32 requestId, const string &nodeName,  const std::string& application,  const std::string& serverName)
@@ -192,11 +192,11 @@ public:
 
 		NODE_LOG(application + "." + serverName)->debug() << result << endl;
 
-		_adminPrx->tars_hash(tars::hash<string>()(nodeName))->async_reportResult(NULL, requestId, __FUNCTION__, ret, result);
+		(*_adminPrxs)[nodeName]->async_reportResult(NULL, requestId, __FUNCTION__, ret, result);
 	}
 
 protected:
-	AdminRegPrx _adminPrx;
+	map<string, AdminRegPrx> *_adminPrxs;
 };
 
 void ServerManager::terminate()
@@ -217,13 +217,7 @@ void ServerManager::initialize(const string &adminObj)
 
 void ServerManager::createAdminPrx()
 {
-	AdminRegPrx prx = Application::getCommunicator()->stringToProxy<AdminRegPrx>(_adminObj);
-
-	NodePushPrxCallbackPtr callback = new AdminNodePushPrxCallback(prx);
-
-	prx->tars_set_push_callback(callback);
-
-	_adminPrx = prx;
+	
 }
 
 void ServerManager::run()
@@ -235,18 +229,40 @@ void ServerManager::run()
 
 	int timeout = 10000;
 
+	NodePushPrxCallbackPtr callback = new AdminNodePushPrxCallback(&_adminPrxs);
+
 	while(!_terminate)
 	{
 		time_t now = TNOWMS;
 
-		try
-		{
-			_adminPrx->tars_set_timeout(timeout/2)->tars_hash(tars::hash<string>()(rn.nodeName))->reportNode(rn);
+		vector<TC_Endpoint> endPointList = Application::getCommunicator()->getEndpoint4All(_adminObj);
+		for(auto endPoint : endPointList)
+		{				
+			auto find = _adminPrxs.find(endPoint.getHost());
+			if(find == _adminPrxs.end())
+			{
+				AdminRegPrx prx = Application::getCommunicator()->stringToProxy<AdminRegPrx>(_adminObj + "@" + endPoint.toString()); 
+				
+				prx->tars_set_push_callback(callback);
+
+				_adminPrxs.insert({endPoint.getHost(),prx});
+
+				TLOG_DEBUG("add AdminRegPrx:" << endPoint.toString() << endl);
+			}
+			
 		}
-		catch(exception &ex)
-		{
-			TLOG_ERROR("report admin, error:" << ex.what() << endl);
-		}
+
+		for(auto adminPrx : _adminPrxs)
+		{				
+			try
+			{ 		
+				adminPrx.second->reportNode(rn);
+			}
+			catch(exception &ex)
+			{
+				TLOG_ERROR("report admin, error:" << ex.what() << endl);
+			}
+		}	
 
 		int64_t diff = timeout-(TNOWMS-now);
 

--- a/NodeServer/ServerManager.h
+++ b/NodeServer/ServerManager.h
@@ -144,8 +144,8 @@ protected:
 	std::mutex _mutex;
 	std::condition_variable _cond;
 	string _adminObj;
-	AdminRegPrx _adminPrx;
-//	map<string, AdminRegPrx> _adminPrxs;
+	//AdminRegPrx _adminPrx;
+    map<string, AdminRegPrx> _adminPrxs;
 };
 
 

--- a/NodeServer/ServerObject.cpp
+++ b/NodeServer/ServerObject.cpp
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Tencent is pleased to support the open source community by making Tars available.
  *
  * Copyright (C) 2016THL A29 Limited, a Tencent company. All rights reserved.

--- a/NodeServer/ServerObject.cpp
+++ b/NodeServer/ServerObject.cpp
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Tencent is pleased to support the open source community by making Tars available.
  *
  * Copyright (C) 2016THL A29 Limited, a Tencent company. All rights reserved.
@@ -830,8 +830,11 @@ bool ServerObject::checkServer(int iTimeout)
         string sResult;
 
 	    int flag = checkPid();
-
-		if(flag != 0 && _state != ServerObject::Inactive && !(_state == ServerObject::Patching || _state==ServerObject::BatchPatching))
+        
+        //可能会出现刚startServer完后，就会马上进行心跳检测。
+        //由于fork子进程后调用的是shell/bat脚本来启动程序，返回的是脚本的pid，需要等待进程上报自己的真实pid。
+        //如果进程还在Activating,并且启动的时间还未超时，不能把状态改成Inactive,否则会出现同时启动了多个进程,端口已被占用错误。
+		if(flag != 0 && _state != ServerObject::Inactive && !(_state == ServerObject::Activating && !isStartTimeOut()) && !(_state == ServerObject::Patching || _state==ServerObject::BatchPatching))
 		{
     		NODE_LOG(_serverId)->info() <<FILE_FUN<< _serverId<<"|" << toStringState(_state) << "|" << _pid << ", flag:" << flag << ", auto start:" << isAutoStart() << endl;
 		    NODE_LOG("KeepAliveThread")->info() <<FILE_FUN<< _serverId<<"|" << toStringState(_state) << "|" << _pid << ", flag:" << flag << ", auto start:" << isAutoStart() << endl;


### PR DESCRIPTION
服务重启时可能会出现 “exit: [TC_Socket::bind] bind error :Address already in use “,  尤其是java服务。
一般主机操作系统重启,拉起框架时比较容易出现。