### PR TITLE
fix findObjectByIdInSameSet return

### DIFF
--- a/RegistryServer/DbHandle.cpp
+++ b/RegistryServer/DbHandle.cpp
@@ -1954,7 +1954,7 @@ int CDbHandle::findObjectByIdInSameSet(const string& sID, const vector<string>& 
     {
         //此情况下没启动set
         TLOGINFO("CDbHandle::findObjectByIdInSameSet:" << __LINE__ << "|" << sID << " haven't start set|" << sSetId << endl);
-        return -1;
+        return -2;
     }
 
     if (vtSetInfo[2] == "*")


### PR DESCRIPTION
指定set调用时，set下无可用节点的时候会随机返回其它set的节点，与预期不符合